### PR TITLE
Save to dated folder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ You can now run this script:
 
 Script options:
 
+**overwriteFiles**
+
+*Type:* `Boolean`<br />
+*Default:* `false`<br />
+
+Overwrite any existing files. If not set, images will be saved in to a dated folder.
+
+For example:
+```js
+overwriteFiles: true
+```
+
 **sizes** is an array of screen sizes you would like to capture.
 
 **steps** is an object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.

--- a/nixon.js
+++ b/nixon.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var sugar = require('sugar');
 var Horseman = require('node-horseman');
 var horseman = new Horseman();
 
@@ -26,15 +27,23 @@ horseman.crop = function( area, path ){
 
 // end patch
 
-var imagePath = "screenshots";
-
 var argv = require('minimist')(process.argv.slice(2));
 
 var scriptName = argv._[0] || "example";
 
+var script = require(path.join(__dirname, 'scripts', scriptName));
+
 console.log("running: " + scriptName);
 
-var script = require(path.join(__dirname, 'scripts', scriptName));
+// Image save path
+var imagePath = "screenshots";
+var stringTime = Date.create().format('{yyyy}-{MM}-{dd}T{hh}-{mm}-{ss}');
+var saveFolder = path.join(imagePath, scriptName);
+
+// If not overwrite, save to datetime folder.
+if (!script.overwrite){
+	saveFolder = path.join(saveFolder, stringTime);
+}
 
 if (!script.keepCookies){
 	horseman.cookies([]);
@@ -67,7 +76,7 @@ for (var name in script.steps){
 
 	script.sizes.forEach(function(size){
 
-		var filename = path.join(imagePath, scriptName, "" + size[0], stepNumber + '-' + name + '.png');
+		var filename = path.join(saveFolder, "" + size[0], stepNumber + '-' + name + '.png');
 		console.log(filename);
 
 		if (size[2] == "crop") {

--- a/nixon.js
+++ b/nixon.js
@@ -40,8 +40,8 @@ var imagePath = "screenshots";
 var stringTime = Date.create().format('{yyyy}-{MM}-{dd}T{hh}-{mm}-{ss}');
 var saveFolder = path.join(imagePath, scriptName);
 
-// If not overwrite, save to datetime folder.
-if (!script.overwrite){
+// If not overwriteFiles, save to datetime folder.
+if (!script.overwriteFiles){
 	saveFolder = path.join(saveFolder, stringTime);
 }
 

--- a/nixon.js
+++ b/nixon.js
@@ -1,7 +1,7 @@
 var path = require('path');
-var sugar = require('sugar');
 var Horseman = require('node-horseman');
 var horseman = new Horseman();
+var moment = require('moment');
 
 // patch horseman.crop
 
@@ -37,7 +37,7 @@ console.log("running: " + scriptName);
 
 // Image save path
 var imagePath = "screenshots";
-var stringTime = Date.create().format('{yyyy}-{MM}-{dd}T{hh}-{mm}-{ss}');
+var stringTime = moment().format('YYYY-MM-DDTHH-mm-ss');
 var saveFolder = path.join(imagePath, scriptName);
 
 // If not overwriteFiles, save to datetime folder.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "nixon.js",
   "dependencies": {
     "minimist": "^1.1.1",
-    "node-horseman": "^1.5.1",
-    "sugar": "^1.4.1"
+    "moment": "^2.10.3",
+    "node-horseman": "^1.5.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "nixon.js",
   "dependencies": {
     "minimist": "^1.1.1",
-    "node-horseman": "^1.5.1"
+    "node-horseman": "^1.5.1",
+    "sugar": "^1.4.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The current nixon functionality will overwrite files by default. This feels 'risky' - better for this to be an explicit instruction by the user. This way repeated runnings at a later date don't risk deleting previous files.

This PR makes nixon save to dated folder by default.

Setting `overwrite = true` in the script will disable this functionality. Useful for testing purposes.
