### PR TITLE
Expand sizes functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,60 +30,61 @@ You can now run this script:
 Script options:
 
 ### sizes
-An array of objects containing the sizes and settings we want for our screenshots.<br />
+An array of objects containing the sizes and settings we want for our screenshots.
+
 *Type:* `Array`<br />
 *Default:* `[{ width: 1024}]`<br />
 
 For example:
 ```js
 sizes: [{
-    width: 320
+	width: 320
 },{
-    name: "iPad",
-    width: 768
+	name: "iPad",
+	width: 768
 }]
 ```
 
-The settings available are as follows:
+Sizes settings are as follows:
 
 * **width**<br />
-  *Type:* `Number`<br />
-  *Default:* 1024<br />
+	*Type:* `Number`<br />
+	*Default:* 1024<br />
 
-  `width` is set in pixels. This is the only option that should be set. If no `name` is specified, the `width` will be used in the image filename.
+	`width` is set in pixels. This is the only option that should be set. If no `name` is specified, the `width` will be used in the image filename.
 
 * **height**<br />
-  *Type:* `Number`<br />
-  *Default:* 100<br />
+	*Type:* `Number`<br />
+	*Default:* 100<br />
 
-  `height` is set in pixels. Note that height is normallly ignored - screenshots will be the height of the content.
+	`height` is set in pixels. Note that height is normallly ignored - screenshots will be the height of the content.
 
 * **name**<br />
-  *Type:* `String`<br />
-  *Default:* size width<br />
+	*Type:* `String`<br />
+	*Default:* size width<br />
 
-  If a `name` is specified, then the file will be suffixed with this name. e.g. `1-start-page-iPad.jpg`<br />
-  If a `name` is not specified, then the file will be suffixed with the width. e.g. `my-image-320.jpg`
+	If a `name` is specified, then the file will be suffixed with this name. e.g. `1-start-page-iPad.png`.<br />
+	If a `name` is not specified, then the file will be suffixed with the width. e.g. `1-start-page-768.png`.
 
 * **suffix**<br />
-  *Type:* `String`<br />
-  *Default:* none<br />
+	*Type:* `String`<br />
+	*Default:* none<br />
 
-  Use `suffix` for retina graphic filenames. e.g. `my-image-320_x2.jpg`
+	Use `suffix` for retina graphic filenames. e.g. `1-start-page-768_x2.png`
 
 * **zoom**<br />
-  *Type:* number<br />
-  *Default:* 1<br />
+	*Type:* number<br />
+	*Default:* 1<br />
 
-  Use `zoom` to set the amount of zoom on the page. Can be used to capture retina graphics with a setting of `zoom: 2`. Note the width and height are scaled by the zoom setting. For example, for an image of `width: 1024` and `zoom: 2`, the captured width will be 2048.
+	Use `zoom` to set the amount of zoom on the page. Can be used to capture retina graphics with a setting of `zoom: 2`. Note the `width` and `height` are scaled by the zoom setting. For example, for an image of `width: 1024` and `zoom: 2`, the captured width will be 2048.
 
 * **crop**<br />
-  *Type:* `string` or `bounding rectangle`<br />
-  *Default:* no crop<br />
+	*Type:* `string` or `bounding rectangle`<br />
+	*Default:* no crop<br />
 
-  Use `crop` to screenshot an area of the page. You can pass in either a CSS selector or a boundingRectangle `{ top : 50, left: 200, width: 90, height: 200 }`.
+	Use `crop` to screenshot an area of the page. You can pass in either a CSS selector or a boundingRectangle `{ top : 50, left: 200, width: 90, height: 200 }`.
 
-  For example:
+	For example:
 	```js
 	sizes: [{
 		name: 'Square crop'
@@ -100,9 +101,7 @@ The settings available are as follows:
 		crop: 'h1'
 	}]
 	```
-	Note if passing a selector, cropping does not scale correctly.
+	Note: `boundingRectangle` scales with zoom, but `selector` does not.
 
 ### steps
 An object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
-
-

--- a/README.md
+++ b/README.md
@@ -29,11 +29,10 @@ You can now run this script:
 
 Script options:
 
-### sizes is an array of screen sizes you would like to capture.
+### sizes
+An array of objects containing the sizes and settings we want for our screenshots.
 *Type:* `Array`<br />
 *Default:* `[{ width: 1024}]`<br />
-
-An array of objects containing the sizes and settings we want for our screenshots.
 
 For example:
 ```js
@@ -103,6 +102,7 @@ The settings available are as follows:
 	```
 	Note if passing a selector, cropping does not scale correctly.
 
-### steps is an object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
+### steps
+An object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
 
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can now run this script:
 
 Script options:
 
-**sizes** is an array of screen sizes you would like to capture.
+### sizes is an array of screen sizes you would like to capture.
 *Type:* `Array`<br />
 *Default:* `[{ width: 1024}]`<br />
 
@@ -87,22 +87,22 @@ The settings available are as follows:
   For example:
 	```js
 	sizes: [{
-			name: 'Square crop'
-	    width: 1024
-	    crop: {
-				top: 100,
-				left: 100,
-				width: 100,
-				height: 100
-	  }
+		name: 'Square crop'
+		width: 1024
+		crop: {
+			top: 100,
+			left: 100,
+			width: 100,
+			height: 100
+		}
 	},{
-	    name: "Page h1",
-	    width: 1024,
-	    crop: 'h1'
+		name: "Page h1",
+		width: 1024,
+		crop: 'h1'
 	}]
 	```
 	Note if passing a selector, cropping does not scale correctly.
 
-**steps** is an object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
+### steps is an object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can now run this script:
 Script options:
 
 ### sizes
-An array of objects containing the sizes and settings we want for our screenshots.
+An array of objects containing the sizes and settings we want for our screenshots.<br />
 *Type:* `Array`<br />
 *Default:* `[{ width: 1024}]`<br />
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,78 @@ You can now run this script:
 Script options:
 
 **sizes** is an array of screen sizes you would like to capture.
+*Type:* `Array`<br />
+*Default:* `[{ width: 1024}]`<br />
+
+An array of objects containing the sizes and settings we want for our screenshots.
+
+For example:
+```js
+sizes: [{
+    width: 320
+},{
+    name: "iPad",
+    width: 768
+}]
+```
+
+The settings available are as follows:
+
+* **width**<br />
+  *Type:* `Number`<br />
+  *Default:* 1024<br />
+
+  `width` is set in pixels. This is the only option that should be set. If no `name` is specified, the `width` will be used in the image filename.
+
+* **height**<br />
+  *Type:* `Number`<br />
+  *Default:* 100<br />
+
+  `height` is set in pixels. Note that height is normallly ignored - screenshots will be the height of the content.
+
+* **name**<br />
+  *Type:* `String`<br />
+  *Default:* size width<br />
+
+  If a `name` is specified, then the file will be suffixed with this name. e.g. `1-start-page-iPad.jpg`<br />
+  If a `name` is not specified, then the file will be suffixed with the width. e.g. `my-image-320.jpg`
+
+* **suffix**<br />
+  *Type:* `String`<br />
+  *Default:* none<br />
+
+  Use `suffix` for retina graphic filenames. e.g. `my-image-320_x2.jpg`
+
+* **zoom**<br />
+  *Type:* number<br />
+  *Default:* 1<br />
+
+  Use `zoom` to set the amount of zoom on the page. Can be used to capture retina graphics with a setting of `zoom: 2`. Note the width and height are scaled by the zoom setting. For example, for an image of `width: 1024` and `zoom: 2`, the captured width will be 2048.
+
+* **crop**<br />
+  *Type:* `string` or `bounding rectangle`<br />
+  *Default:* no crop<br />
+
+  Use `crop` to screenshot an area of the page. You can pass in either a CSS selector or a boundingRectangle `{ top : 50, left: 200, width: 90, height: 200 }`.
+
+  For example:
+	```js
+	sizes: [{
+			name: 'Square crop'
+	    width: 1024
+	    crop: {
+				top: 100,
+				left: 100,
+				width: 100,
+				height: 100
+	  }
+	},{
+	    name: "Page h1",
+	    width: 1024,
+	    crop: 'h1'
+	}]
+	```
+	Note if passing a selector, cropping does not scale correctly.
 
 **steps** is an object - each property is a step you would like take in order to get a screenshot. If it's a string, Nixon will open the URL. If it's a function, it will be run in the browser. You can use jQuery commands.
 

--- a/nixon.js
+++ b/nixon.js
@@ -32,19 +32,38 @@ var argv = require('minimist')(process.argv.slice(2));
 
 var scriptName = argv._[0] || "example";
 
-console.log("running: " + scriptName);
 
 var script = require(path.join(__dirname, 'scripts', scriptName));
+
+console.log('\nNixon.js - running: ' + scriptName);
+
+// console.log('sizes', script.sizes);
 
 if (!script.keepCookies){
 	horseman.cookies([]);
 }
 
+if (!script.sizes){
+	console.log('No sizes set, using default (1024px)');
+	script.sizes = [{
+			width: 1024
+		}];
+}
+
+var numSteps = 0;
+for (var step in script.steps){
+	numSteps++;
+}
+var numSizes = script.sizes.length;
+var numScreenshots = numSteps * numSizes;
+console.log('Total screenshots:', numScreenshots, '(' + numSteps, 'steps,', numSizes, 'sizes per step)');
+
+var errorCount = 0;
 var stepNumber = 1;
 
 for (var name in script.steps){
 	
-	console.log(stepNumber + ": " + name);
+	process.stdout.write('\nStep ' + stepNumber + " - " + name);
 
 	var step = script.steps[name];
 
@@ -63,29 +82,63 @@ for (var name in script.steps){
 	horseman.waitForNextPage();
 
 	//console.log("... done waiting");
-	console.log(horseman.url());
+	console.log(':', horseman.url());
 
+	var sizeCount = 1;
 	script.sizes.forEach(function(size){
 
-		var filename = path.join(imagePath, scriptName, "" + size[0], stepNumber + '-' + name + '.png');
-		console.log(filename);
-
-		if (size[2] == "crop") {
-
-			console.log('crop');
-			horseman
-				.viewport(size[0], size[1])
-				.crop({ top : 0, left: 0, width: size[0], height: size[1] }, filename);
-
+		var image= {};
+		if ( !size.width ) {
+			errorCount++;
+			image.width = 1024; //default width
 		} else {
+			image.width = size.width;
+		}
+		image.height = (size.height) ? size.height : 100;
+		image.name = (size.name) ? size.name : image.width;
+		image.zoom = (size.zoom) ? size.zoom : 1;
+		image.suffix = (size.suffix) ? size.suffix : '';
 
-			console.log('screenshot');
+		var imageName = stepNumber + '-' + name + '-' + image.name + image.suffix + '.png';
+		var filename = path.join(imagePath, scriptName, String(image.name), imageName);
+		
+		horseman
+			.zoom(image.zoom)
+			.viewport((image.zoom * image.width), (image.zoom * image.height));
+
+		if (size.crop) {
+			console.log('\tSize', sizeCount, '-', image.name + ' (cropped):', imageName);
+			image.crop = size.crop;
+			if ( typeof size.crop === "string" ) {
+				// Don't crop if selector doesn't exist
+				if (!horseman.exists(size.crop)){
+					errorCount++;
+					console.warn('\tError: selector does not exist');
+				}
+				else {
+					image.crop = size.crop;
+					horseman.crop(image.crop, filename);
+				}
+			}
+			else {
+				image.crop.top = image.zoom * size.crop.top;
+				image.crop.left = image.zoom * size.crop.left;
+				image.crop.width = image.zoom * size.crop.width;
+				image.crop.height = image.zoom * size.crop.height;
+				horseman.crop(image.crop, filename);
+			}
+		} else {
+			console.log('\tSize', sizeCount, '-', image.name + ':', imageName);
 			horseman
-				.viewport(size[0], size[1])
 				.screenshot(filename);
-
 		}
 
+		// Width error appears after screenshot
+		if (!size.width){
+			console.warn('\tError: width not set - using default (1024px)');
+		}
+
+		sizeCount++;
 	});
 
 	stepNumber++;
@@ -93,4 +146,7 @@ for (var name in script.steps){
 }
 
 horseman.close();
-console.log("All done");
+
+var errorText = (errorCount != 1) ? 'errors' : 'error';
+var endMessage = (errorCount) ? (' - ' + errorCount + ' ' + errorText) : '';
+console.log("\nAll done" + endMessage);

--- a/scripts/example.js
+++ b/scripts/example.js
@@ -4,9 +4,34 @@ module.exports = {
     username: "",
     password: "",
 
-    sizes : [
-        [1024,768],
-        [320,480]
+    sizes: [
+        {
+            width: 320
+        },
+        {
+            width: 1024,
+        },
+        {
+            name: "iPad",
+            width: 768,
+            zoom: 2,
+            suffix: '_x2'
+        },
+        {
+            name: "Page headings",
+            width: 1024,
+            crop: 'h1'
+        },
+        {
+            name: "Square crop",
+            width: 1024,
+            crop: {
+                top : 100,
+                left: 100,
+                width: 100,
+                height: 100
+            }
+        }
     ],
 
     steps : {


### PR DESCRIPTION
This PR brings the sizes API closer to other packages - eg [grunt-responsive-images](https://github.com/andismith/grunt-responsive-images/#options). It also means sizes can have more functionnality - eg cropping and zoom.

Changes:
- Sizes to array of objects.
- Lets user set zoom (width and height scaled by zoom)
- Lets user set an optional name to be used instead of width
- Lets user set an optional suffix (for retina graphics)
- Lets user set a crop - either by selector or by bounding rectangle
- Update readme and `example.js` with examples

Other small changes:
- Cleanup of console.log for legibility
- Counts number of images
- Counts number of errors
- Sizes no longer required (has a default of a single 1024 width size)
- Checks that selector exists before cropping to it.
